### PR TITLE
KON-118: Org shared workflows

### DIFF
--- a/.github/actions/checkout/action.yaml
+++ b/.github/actions/checkout/action.yaml
@@ -1,0 +1,15 @@
+name: Checkout
+description: Checkout repository code
+
+inputs:
+  ref:
+    description: Branch or commit to checkout
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.ref }}

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,0 +1,15 @@
+name: Setup Node.js
+description: Setup Node.js runtime
+
+inputs:
+  node-version:
+    description: Node.js version
+    required: false
+    default: '24.x'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version: ${{ inputs.node-version }}

--- a/.github/actions/setup-terraform/action.yaml
+++ b/.github/actions/setup-terraform/action.yaml
@@ -1,0 +1,20 @@
+name: Setup Terraform
+description: Setup Terraform CLI with optional Terraform Cloud token
+
+inputs:
+  terraform-version:
+    description: Terraform version
+    required: false
+    default: '1.14.3'
+  token:
+    description: Terraform Cloud API token
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+      with:
+        terraform_version: ${{ inputs.terraform-version }}
+        cli_config_credentials_token: ${{ inputs.token }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: "terraform"
-    directory: "/"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+      interval: "cron"
+      cronjob: "40 14 28 * *"
     groups:
-      aws-packages:
+      github-actions:
         patterns:
-          - "@aws-sdk/*"
-          - "@types/aws-lambda"
+          - "*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Purpose
+
+This is the `.github` repository for the Brevis GitHub organization (`brevisdev`). It contains shared composite actions, default community health files (CODEOWNERS, Dependabot config), and organization-wide settings that apply across all Brevis repos.
+
+## Architecture
+
+### Composite Actions
+
+Located in `.github/actions/`, these wrap upstream actions with pinned versions so all org repos share a single version source:
+
+| Action | Wraps | Default |
+|--------|-------|---------|
+| `checkout` | `actions/checkout` | — |
+| `setup-node` | `actions/setup-node` | Node.js 24.x |
+| `setup-terraform` | `hashicorp/setup-terraform` | Terraform 1.14.3 |
+
+Actions are consumed via: `brevisdev/.github/.github/actions/<name>@main`
+
+All upstream action references use **pinned commit SHAs** with version comments (e.g., `actions/checkout@<sha> # v6.0.2`).
+
+### Organization Defaults
+
+- `.github/CODEOWNERS` — Default code owners (`@unknoundev/core`)
+- `.github/dependabot.yml` — Monthly GitHub Actions version update checks (28th of each month)
+
+## Conventions
+
+- When adding or updating a composite action, pin the upstream action to a **full commit SHA** and add a version comment
+- Each action lives in its own directory under `.github/actions/<action-name>/` with an `action.yaml` using `using: composite`
+- After changing an action version here, all consuming repos automatically pick up the change on their next workflow run (they reference `@main`)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# template-base
-Base template for all repositories
+# .github
+
+Shared GitHub configuration for the Brevis organization. Contains composite actions, default community health files, and organization-wide settings.
+
+## Composite Actions
+
+Centralized action wrappers so action versions are managed in one place. Update the version here and all repos pick it up.
+
+### checkout
+
+Wraps `actions/checkout`.
+
+```yaml
+- uses: brevisdev/.github/.github/actions/checkout@main
+  with:
+    ref: ${{ inputs.branch }}  # optional
+```
+
+### setup-node
+
+Wraps `actions/setup-node`. Defaults to Node.js 24.x.
+
+```yaml
+- uses: brevisdev/.github/.github/actions/setup-node@main
+
+# or with a specific version
+- uses: brevisdev/.github/.github/actions/setup-node@main
+  with:
+    node-version: '22.x'
+```
+
+## Organization Defaults
+
+- `.github/CODEOWNERS` — Default code owners for all repos
+- `.github/dependabot.yml` — Default Dependabot configuration
+
+## Adding a New Composite Action
+
+1. Create a directory under `.github/actions/<action-name>/`
+2. Add `action.yaml` with `using: composite`
+3. Document usage in this README
+4. Update consuming repos to use `brevisdev/.github/.github/actions/<action-name>@main`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Wraps `actions/setup-node`. Defaults to Node.js 24.x.
     node-version: '22.x'
 ```
 
+### setup-terraform
+
+Wraps `hashicorp/setup-terraform`. Defaults to Terraform 1.14.3.
+
+```yaml
+- uses: brevisdev/.github/.github/actions/setup-terraform@main
+  with:
+    token: ${{ secrets.TF_API_TOKEN }}  # optional, for Terraform Cloud
+```
+
 ## Organization Defaults
 
 - `.github/CODEOWNERS` — Default code owners for all repos


### PR DESCRIPTION
[KON-118](https://brevisou.atlassian.net/browse/KON-118)

This pull request introduces several new composite GitHub Actions for the organization, centralizes action version management, and updates documentation and configuration files to reflect these changes. The primary goal is to standardize and simplify CI/CD workflows across repositories by providing reusable, version-pinned action wrappers and clearer documentation.

**New composite actions and documentation:**

* Added three composite actions for common workflows:
  - [`checkout`](diffhunk://#diff-16cd30178fc63e2de2f77a4dd3abe5da2adacb622355cbaa221d3f04a3342f66R1-R15): Wraps `actions/checkout` with version pinning and optional `ref` input. (.github/actions/checkout/action.yaml)
  - [`setup-node`](diffhunk://#diff-3a058c25742c0416fac0d817856f76372f2359751220d2940396f8c1176f6335R1-R15): Wraps `actions/setup-node`, defaults to Node.js 24.x, and allows overriding the version. (.github/actions/setup-node/action.yaml)
  - [`setup-terraform`](diffhunk://#diff-2ecbcf4a7195467f2e26b9f2aa8b4d491733beab82489b5712d75eba4b8f76dfR1-R20): Wraps `hashicorp/setup-terraform`, defaults to Terraform 1.14.3, and supports optional Terraform Cloud token. (.github/actions/setup-terraform/action.yaml)
* Updated `README.md` to document the purpose of the repository, usage of the new composite actions, and instructions for adding new actions.

**Configuration improvements:**

* Updated `.github/dependabot.yml`:
  - Removed unused `terraform` and `npm` package-ecosystem entries.
  - Changed the schedule for GitHub Actions updates to use a monthly cron job.
  - Renamed and broadened the update group to cover all GitHub Actions.

[KON-118]: https://brevisou.atlassian.net/browse/KON-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ