### PR TITLE
KON-128: Shared PR approve workflow

### DIFF
--- a/.github/workflows/auto-approve-pr.yaml
+++ b/.github/workflows/auto-approve-pr.yaml
@@ -1,0 +1,9 @@
+name: Auto Approve
+on:
+  pull_request:
+    types: [ready_for_review]
+jobs:
+  auto-approve:
+    uses: brevisdev/.github/.github/workflows/pr-auto-approve.yaml@main
+    secrets:
+      PR_REVIEW_PAT: ${{ secrets.PR_REVIEW_PAT }}

--- a/.github/workflows/pr-auto-approve.yaml
+++ b/.github/workflows/pr-auto-approve.yaml
@@ -1,0 +1,15 @@
+name: Auto Approve
+
+on:
+  workflow_call:
+    secrets:
+      PR_REVIEW_PAT:
+        required: true
+
+jobs:
+  approve:
+    runs-on: self-hosted
+    steps:
+      - run: gh pr review ${{ github.event.pull_request.number }} --approve --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.PR_REVIEW_PAT }}

--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ jobs:
     secrets: inherit
 ```
 
+### pr-auto-approve
+
+Auto-approves a PR when it is marked as ready for review. Requires a `PR_REVIEW_PAT` secret with a PAT that has permission to approve PRs.
+
+```yaml
+# In consuming repo: .github/workflows/pr-auto-approve.yaml
+name: Auto Approve
+on:
+  pull_request:
+    types: [ready_for_review]
+jobs:
+  auto-approve:
+    uses: brevisdev/.github/.github/workflows/pr-auto-approve.yaml@main
+    secrets:
+      PR_REVIEW_PAT: ${{ secrets.PR_REVIEW_PAT }}
+```
+
 ## Organization Defaults
 
 - `.github/CODEOWNERS` — Default code owners for all repos


### PR DESCRIPTION
[KON-128](https://brevisou.atlassian.net/browse/KON-128)

This pull request introduces an automated workflow to auto-approve pull requests when they are marked as ready for review. It adds the necessary workflow files and documentation to enable this functionality using a GitHub Actions workflow that leverages a personal access token (PAT) for approval.

**Workflow automation:**

* Added `.github/workflows/auto-approve-pr.yaml` to trigger the auto-approve workflow when a pull request is marked as ready for review, delegating to a reusable workflow and passing the required secret (`PR_REVIEW_PAT`).
* Introduced `.github/workflows/pr-auto-approve.yaml` as a reusable workflow that performs the approval using the GitHub CLI, requiring a `PR_REVIEW_PAT` secret for authentication.

**Documentation:**

* Updated `README.md` to document the new `pr-auto-approve` workflow, including usage instructions and requirements for the `PR_REVIEW_PAT` secret.

[KON-128]: https://brevisou.atlassian.net/browse/KON-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ